### PR TITLE
Changes required to allow successful execution of tap-postgres.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ setup(
     install_requires=[
         'pyyaml>=4.2b1',
         'smart-open==1.8.0',
-        'click==7.0',
-        'dataclasses'
+        'click==7.0'
     ],
     tests_require=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyyaml>=4.2b1',
-        'smart-open==1.7.1'
+        'smart-open==1.8.0'
     ],
     tests_require=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pyyaml>=4.2b1',
-        'smart-open==1.8.0'
+        'smart-open==1.8.0',
+        'click==7.0',
+        'dataclasses'
     ],
     tests_require=[
     ],

--- a/singer_runner/cli.py
+++ b/singer_runner/cli.py
@@ -12,7 +12,7 @@ except ImportError:
 from singer_runner.runner import run_tap
 from singer_runner.state import FileStateStorage
 from singer_runner.metrics import FileMetricsStorage
-from singer_runner.pipes import FilePipe, MemoryPipe, StdInOutPipe
+from singer_runner.pipes import FilePipe, StdInOutPipe
 
 CONFIG_STATE_STORAGE_CLASSES = {
     'file': FileStateStorage

--- a/singer_runner/metrics/file.py
+++ b/singer_runner/metrics/file.py
@@ -7,11 +7,11 @@ class FileMetricsStorage(BaseMetricsStorage):
         self.filepath = filepath
         self.file = smart_open(filepath, 'w', **kwargs)
 
-        super(FilePipe, self).__init__(*args, **kwargs)
+        super(FileMetricsStorage, self).__init__(*args, **kwargs)
 
     def close(self):
-        super(FilePipe, self).close()
+        super(FileMetricsStorage, self).close()
         self.file.close()
 
     def put(self, raw_singer_metric):
-        self.file.write(raw_singer_metric + b'\n')
+        self.file.write(raw_singer_metric + '\n')

--- a/singer_runner/pipes/file.py
+++ b/singer_runner/pipes/file.py
@@ -7,7 +7,6 @@ class FilePipe(BasePipe):
         self.filepath = filepath
         self.mode = mode
         self.file = smart_open(filepath, mode, **kwargs)
-        self.linefeed = b'\n' if mode == 'wb' else '\n'
 
         super(FilePipe, self).__init__(*args, **kwargs)
 
@@ -16,7 +15,7 @@ class FilePipe(BasePipe):
         self.file.close()
 
     def put(self, raw_singer_message):
-        self.file.write(raw_singer_message + self.linefeed)
+        self.file.write(raw_singer_message + b'\n')
 
     def get(self):
         return self.file.readline()

--- a/singer_runner/pipes/file.py
+++ b/singer_runner/pipes/file.py
@@ -7,6 +7,7 @@ class FilePipe(BasePipe):
         self.filepath = filepath
         self.mode = mode
         self.file = smart_open(filepath, mode, **kwargs)
+        self.linefeed = b'\n' if mode == 'wb' else '\n'
 
         super(FilePipe, self).__init__(*args, **kwargs)
 
@@ -15,7 +16,7 @@ class FilePipe(BasePipe):
         self.file.close()
 
     def put(self, raw_singer_message):
-        self.file.write(raw_singer_message + b'\n')
+        self.file.write(raw_singer_message + self.linefeed)
 
     def get(self):
         return self.file.readline()

--- a/singer_runner/process.py
+++ b/singer_runner/process.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 from subprocess import Popen, PIPE
 
-from singer_runner.utils import EOF, EMPTYLINE, TAP, TARGET, run_thread, terminate_queue
+from singer_runner.utils import EOF, EMPTYLINE, TAP, TARGET, run_thread
 
 ON_POSIX = 'posix' in sys.builtin_module_names
 
@@ -48,8 +48,7 @@ class SingerProcess:
                  singer_process_type=TAP,
                  pipe=None,
                  metrics_storage=None,
-                 state_storage=None,
-                 output_stream_queue_size=0):
+                 state_storage=None):
         self.started_at = datetime.utcnow()
         self.singer_process_type = singer_process_type
         self.pipe = pipe

--- a/singer_runner/runner.py
+++ b/singer_runner/runner.py
@@ -2,15 +2,11 @@ import json
 from tempfile import NamedTemporaryFile
 
 from singer_runner.process import SingerProcess
-from singer_runner.pipes import FilePipe
-from singer_runner.state import FileStateStorage
 from singer_runner.utils import (
-    run_thread,
-    EOF,
     TAP,
-    TARGET,
-    create_queue
+    TARGET
 )
+
 
 def create_temp_json_file(obj):
     file = NamedTemporaryFile(mode='w')
@@ -57,7 +53,6 @@ def run_tap(logger,
             metrics_storage=None,
             pipe=None):
     temp_files = []
-    process = None
 
     command = [tap_command]
 
@@ -106,7 +101,6 @@ def run_target(logger,
                metrics_storage=None,
                pipe=None):
     temp_files = []
-    process = None
 
     command = [target_command]
 

--- a/singer_runner/state/file.py
+++ b/singer_runner/state/file.py
@@ -16,6 +16,8 @@ class FileStateStorage(BaseStateStorage):
 
     def load(self):
         with smart_open(self.filepath, 'r') as file:
-            state = json.load(self.file)
-        self.state = state
-        return state
+            try:
+                self.state = json.load(file)
+            except ValueError:
+                self.state = None
+        return self.state

--- a/singer_runner/state/file.py
+++ b/singer_runner/state/file.py
@@ -15,9 +15,9 @@ class FileStateStorage(BaseStateStorage):
         self.state = state
 
     def load(self):
-        with smart_open(self.filepath, 'r') as file:
-            try:
+        try:
+            with smart_open(self.filepath, 'r') as file:
                 self.state = json.load(file)
-            except ValueError:
-                self.state = None
+        except ValueError:
+            self.state = None
         return self.state

--- a/singer_runner/utils.py
+++ b/singer_runner/utils.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass, field
-from typing import Any
 from queue import PriorityQueue
 from threading import Thread
 
@@ -14,20 +12,6 @@ def run_thread(fn, args):
     thread.start()
     return thread
 
-@dataclass(order=True)
-class PrioritizedItem:
-    priority: int
-    item: Any=field(compare=False)
-
 def create_queue(maxsize=0):
     return PriorityQueue(maxsize)
 
-def queue_put(queue, item, priority=2, **kwargs):
-    queue.put(PrioritizedItem(priority, item=item), **kwargs)
-
-def queue_get(queue, **kwargs):
-    prioritized_item = queue.get(**kwargs)
-    return prioritized_item.item
-
-def terminate_queue(queue, **kwargs):
-    queue_put(queue, EOF, priority=1, **kwargs)


### PR DESCRIPTION
- Changing type passed to parent in metrics/file to self.
- Adding string version of linefeed instead of binary to fix issue with writing metrics.
- Catching exception that can occur when state file is empty of not present in state/file.  Note this required an upgrade of smart-open in order to catch both cases. 

Here's the config I used (based on [this]( https://gist.github.com/awm33/3e327359ca0f996499a059a5646ad899) but with changes to tap).

```
tap_command: /home/rob/python-virtual-env/tap-postgres/bin/tap-postgres
tap_config_path: /home/rob/tap-postgres-config.json
tap_catalog_path: /home/rob/tap-postgres-properties.json
tap_state:
  type: file
  options:
    - s3://rob-singer-runner/taps/postgres_state.json
metrics:
  type: file
  options:
    - s3://rob-singer-runner/taps/postgres_metrics_last_run.json
pipe:
  type: file
  options:
    - s3://rob-singer-runner/taps/postgres_stream_last_run.json
    - w
```